### PR TITLE
replace setTimeout

### DIFF
--- a/withSubscribe.js
+++ b/withSubscribe.js
@@ -1,7 +1,7 @@
 module.exports = createStore => (reducer,...args) => {
   const listeners = []
   const wrapped = (state, action) => (
-    action && action.type != '@@init' && setTimeout(() => listeners.forEach(listener => listener()), 0),
+    action && action.type != '@@init' && window.requestAnimationFrame(() => listeners.forEach(listener => listener())),
     reducer(state, action)
   )
   const store = createStore(wrapped, ...args)


### PR DESCRIPTION
Hi,

great library first of all! :+1: 

I've managed to get it running to replace redux, but I ran into syncing issues for async components.

After some deep digging I found out, that `setTimeout(fn, 0)` is evil and should be replaced by `requestAnimationFrame(fn)` which is way more predictable when it is executed.

For more info, check https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame

Have a nice week
midzer